### PR TITLE
Fix XML show_warnings typo

### DIFF
--- a/BmwDeepObd/JobReader.cs
+++ b/BmwDeepObd/JobReader.cs
@@ -590,7 +590,7 @@ namespace BmwDeepObd
                             if (string.Compare(xnodePageChild.Name, "code", StringComparison.OrdinalIgnoreCase) == 0)
                             {
                                 classCode = xnodePageChild.InnerText;
-                                attrib = xnodePageChild.Attributes["show_warnigs"];
+                                attrib = xnodePageChild.Attributes["show_warnings"];
                                 if (attrib != null)
                                 {
                                     try

--- a/BmwDeepObd/Xml/Adapter.ccpage
+++ b/BmwDeepObd/Xml/Adapter.ccpage
@@ -20,7 +20,7 @@
       <string name="adapter_config_ok">Konfiguration erfolgreich</string>
     </strings>
     <jobs sgbd="adapter_prg" />
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/AdapterCustom.ccpage
+++ b/BmwDeepObd/Xml/AdapterCustom.ccpage
@@ -44,7 +44,7 @@
       <string name="adapter_ignition_on">An</string>
     </strings>
     <jobs sgbd="adapter_prg" />
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/BmwDeepObd.xsd
+++ b/BmwDeepObd/Xml/BmwDeepObd.xsd
@@ -525,7 +525,7 @@
         ]]>
       </xs:documentation>
     </xs:annotation>
-    <xs:attribute name="show_warnigs" type="xs:boolean" default="false" use="optional">
+    <xs:attribute name="show_warnings" type="xs:boolean" default="false" use="optional">
       <xs:annotation>
         <xs:documentation>
           Show warnings during compilation of user code.

--- a/BmwDeepObd/Xml/E61/Axis.ccpage
+++ b/BmwDeepObd/Xml/E61/Axis.ccpage
@@ -40,7 +40,7 @@
       <string name="label_axis_valve_state">Zustand Ausgänge:</string>
     </strings>
     <jobs sgbd="d_ehc" />
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E61/Ccc.ccpage
+++ b/BmwDeepObd/Xml/E61/Ccc.ccpage
@@ -50,7 +50,7 @@
         <display name="label_ccc_nav_res_pos" result="STAT_POSITION_AUFLOES" format="T" />
       </job>
     </jobs>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E61/Errors.ccpage
+++ b/BmwDeepObd/Xml/E61/Errors.ccpage
@@ -89,7 +89,7 @@
       <ecu name="SZM" sgbd="d_bzm" />
       <ecu name="TCU" sgbd="d_tel" />
     </read_errors>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E61/Motor.ccpage
+++ b/BmwDeepObd/Xml/E61/Motor.ccpage
@@ -90,7 +90,7 @@
         <display name="label_motor_accel" result="STAT_FAHRZEUGBESCHLEUNIGUNG_WERT" format="6.2R" />
       </job>
     </jobs>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E61/MotorGrid.ccpage
+++ b/BmwDeepObd/Xml/E61/MotorGrid.ccpage
@@ -90,7 +90,7 @@
         <display name="label_motor_accel" result="STAT_FAHRZEUGBESCHLEUNIGUNG_WERT" format="6.2R" />
       </job>
     </jobs>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E61/Test.ccpage
+++ b/BmwDeepObd/Xml/E61/Test.ccpage
@@ -10,7 +10,7 @@
       <string name="tab_test">Test</string>
     </strings>
     <jobs />
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E61R/BmwDeepObd.xsd
+++ b/BmwDeepObd/Xml/E61R/BmwDeepObd.xsd
@@ -525,7 +525,7 @@
         ]]>
       </xs:documentation>
     </xs:annotation>
-    <xs:attribute name="show_warnigs" type="xs:boolean" default="false" use="optional">
+    <xs:attribute name="show_warnings" type="xs:boolean" default="false" use="optional">
       <xs:annotation>
         <xs:documentation>
           Show warnings during compilation of user code.

--- a/BmwDeepObd/Xml/E61R/Combined.ccpage
+++ b/BmwDeepObd/Xml/E61R/Combined.ccpage
@@ -83,7 +83,7 @@
         <display name="label_pdc_hr" result="1#STAT_HR_WERT" format="3L" log_tag="pdc_hr" />
       </job>
     </jobs>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/BmwDeepObd/Xml/E90/Motor.ccpage
+++ b/BmwDeepObd/Xml/E90/Motor.ccpage
@@ -87,7 +87,7 @@
         <display name="label_motor_part_filt_dist_remain" result="STAT_PCBS_lDistanceOut_WERT" format="6.0R"/>
       </job>
     </jobs>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {

--- a/docs/Page_specification.md
+++ b/docs/Page_specification.md
@@ -199,7 +199,7 @@ In the `ecu` node the property `name` is a link to a `string` node and `sgbd` is
 If the jobs and display output is getting more complex, user defined code will be required. In this case a C# class could be added to a `code` node, which defines a set of optional callback functions. If the `show_warnings` property is set to true, also warnings will be reported during compilation of the code.  
 **In the current Mono CSharp compiler there is a bug that reports an error, if initialized arrays are used in the user defined code. To prevent this, initialize the array (or list) in the constructor of `PageClass`!**
 ``` xml
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {
@@ -312,7 +312,7 @@ Here is an example from the errors page, that adds a RPM value to the error mess
       <ecu name="CAS" sgbd="d_cas" />
       <ecu name="DDE" sgbd="d_motor" results="F_UW_KM;F_UW_ANZ" />
     </read_errors>
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {
@@ -603,7 +603,7 @@ The resulting page will look like this:
 For interaction of the user code with other apps the broadcast `de.holeschak.bmw_deep_obd.Action.Command` could by processed by the function `BroadcastReceived`.  
 Here is an example from the axis page, that changes the axis direction with the broadcast.
 ``` xml
-    <code show_warnigs="true">
+    <code show_warnings="true">
       <![CDATA[
     class PageClass
     {


### PR DESCRIPTION
In the examples and the documentation, the 'show_warnings' XML attribute for displaying the CS errors on compilation had a typographical error, instead being spelled 'show_warnigs'. I have fixed that.