### PR TITLE
Voltage bridge: OBD thread-safety redesign (CommThread) + ENET passive clamp snoop

### DIFF
--- a/EdiabasLib/EdiabasLib/EdInterfaceBase.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceBase.cs
@@ -704,6 +704,17 @@ namespace EdiabasLib
             get { return "IFH-STD Version 7.6.0"; }
         }
 
+#if NETFRAMEWORK
+        // Strictly passive hook: invoked by EdiabasNet at the end of a user ExecuteJob with the
+        // job name, its string arguments, and the result sets it just produced. Default no-op.
+        // Concrete interfaces may opportunistically surface side-information (e.g. clamp state from
+        // an observed STEUERN_KLEMMEN command) WITHOUT generating any extra bus traffic. Must never
+        // throw and must never touch interface I/O.
+        public virtual void OnJobCompleted(string jobName, List<string> argStrings, List<Dictionary<string, EdiabasNet.ResultData>> resultSets)
+        {
+        }
+#endif
+
         public abstract byte[] KeyBytes { get; }
 
         public abstract byte[] State { get; }

--- a/EdiabasLib/EdiabasLib/EdInterfaceEnet.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceEnet.cs
@@ -1610,23 +1610,24 @@ namespace EdiabasLib
         }
 
 #if NETFRAMEWORK
-        // ENET clamp following is command-snoop based, NOT a live read: the vehicle exposes no KL15
-        // over the diagnostic bus (on a genuine setup it is an ICOM/SLP hardware signal, cf. ISTA
-        // VCIDevice.GetClamp15 <- SLP advertisement). So instead of polling the control channel
-        // (unreliable: it is never queried for ignition and the connection churns), we passively
-        // mirror ISTA's own explicit clamp-control commands as they cross the wire. Invoked by
-        // EdiabasNet at the end of each user ExecuteJob - no extra bus traffic, no thread, no I/O.
-        // Recognized signals (per ISTA 4.59.20 variant analysis + live traces):
-        //   * STEUERN_KLEMMEN arg KL15_EIN                       -> KL15 on  (restore)
-        //   * STEUERN_KLEMMEN arg KL30B/KL30F/..._VERK/KLR/AUS   -> KL15 off (non-ignition clamp)
-        //   * STEUERN_ROUTINE arg STEUERN_KL15_ABSCHALTUNG /     -> KL15 off (shutdown; also the
-        //       KLEMME15 fallback spelling, or routine id 0xAC51 used by CAS4_2)
-        //   * STEUERN_KL15_ABSCHALTUNG as a direct job (BN2000)  -> KL15 off
-        //   * STATUS_LESEN/STATUS_KLEMMEN STAT_KLEMMENSTATUS_TEXT -> live state + session baseline
-        // Every other job leaves the held state untouched. We deliberately do NOT infer "on" from
-        // arbitrary successful jobs (that masks a real off within milliseconds) and never read fault
-        // freeze-frames (their KLEMMEN fields are historical, not the live state). The consumer
-        // holds the last state and restores ON on KL15_EIN (or via its own safety timeout).
+        // ENET clamp following without a live bus read: the vehicle exposes no KL15 of its own over
+        // diagnostics (on a genuine setup it is an ICOM/SLP hardware signal, cf. ISTA
+        // VCIDevice.GetClamp15 <- SLP) and the HSFZ control channel is never reliably queried for
+        // ignition (it also churns). Instead we read the clamp state the vehicle itself REPORTS, by
+        // passively inspecting jobs ISTA already runs. Invoked by EdiabasNet at the end of each user
+        // ExecuteJob - no extra bus traffic, no thread, no I/O. Two confirmed sources + one intent:
+        //   1. CONFIRMED - the ECU's reported clamp-status text:
+        //        * STEUERN_KLEMMEN  -> result STAT_CAS_KLEMMEN_STATUS_TEXT (post-switch state)
+        //        * STATUS_LESEN/STATUS_KLEMMEN -> result STAT_KLEMMENSTATUS_TEXT (live read + baseline)
+        //      "KL15" => on; "KL30..."/"KLR..." => off. This is the byte the BDC/CAS returns
+        //      (0x0A=KL15, 0x06=KL30B; decoded by text, not a & 0x01 bit test).
+        //   2. INTENT (only for the shutdown routine, which has no status-text result):
+        //        * STEUERN_ROUTINE STEUERN_KL15_ABSCHALTUNG (or KLEMME15 fallback, or routine id
+        //          0xAC51 on CAS4_2), and STEUERN_KL15_ABSCHALTUNG as a direct job (BN2000) => off.
+        // Every other job leaves the held state untouched. We never infer "on" from arbitrary jobs
+        // and never read fault freeze-frames (their KLEMMEN fields are historical, not live). If a
+        // STEUERN_KLEMMEN command produced no status text (rejected/failed), we hold rather than
+        // trust the requested arg - the consumer keeps the last confirmed state.
         public override void OnJobCompleted(string jobName, List<string> argStrings, List<Dictionary<string, EdiabasNet.ResultData>> resultSets)
         {
             if (!EnableVoltageSamplerProtected)
@@ -1637,77 +1638,66 @@ namespace EdiabasLib
             {
                 return;
             }
-            // An explicit command takes priority (immediate reaction); otherwise an authoritative
-            // STATUS_KLEMMEN read gives the live state, including the session-start baseline.
-            bool? clampOn = InferClampFromCommand(jobName, argStrings)
-                            ?? InferClampFromStatus(jobName, argStrings, resultSets);
+            // Prefer the vehicle-confirmed status text; fall back to the shutdown-routine intent
+            // (those jobs carry no clamp-status result, only a positive ACK).
+            bool? clampOn = InferClampFromConfirmedStatus(jobName, argStrings, resultSets)
+                            ?? InferClampFromShutdownCommand(jobName, argStrings);
             if (!clampOn.HasValue)
-            {   // neither a clamp command nor a clamp status read: hold the last published state
+            {   // nothing authoritative this job: hold the last published state
                 return;
             }
             EdiabasVoltageBridge.Sample(true, clampOn, IgnitionVoltageValue, BatteryVoltageValue, RemoteHostProtected);
         }
 
-        private static bool? InferClampFromCommand(string jobName, List<string> argStrings)
+        // The clamp state the ECU actually reports, from the result set of the job ISTA just ran:
+        //   * STEUERN_KLEMMEN          -> STAT_CAS_KLEMMEN_STATUS_TEXT (state confirmed after the switch)
+        //   * STATUS_LESEN/STATUS_KLEMMEN -> STAT_KLEMMENSTATUS_TEXT   (live read, incl. session baseline)
+        // Strictly scoped to those job+result names so it never reads a fault freeze-frame's KLEMMEN
+        // field (which is historical, not the live state).
+        private static bool? InferClampFromConfirmedStatus(string jobName, List<string> argStrings, List<Dictionary<string, EdiabasNet.ResultData>> resultSets)
         {
-            // Direct shutdown job (BN2000 / d_cas): the routine is the job itself, not a ROUTINE arg.
-            if (string.Equals(jobName, "STEUERN_KL15_ABSCHALTUNG", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-            // Direct clamp switch. KL15_EIN = ignition on; every other target clamp (KL30B/KL30F/
-            // shortened-nachlauf VERK / KLR / explicit AUS) means KL15 off.
+            string resultName = null;
             if (string.Equals(jobName, "STEUERN_KLEMMEN", StringComparison.OrdinalIgnoreCase))
             {
-                if (ArgContains(argStrings, "KL15_EIN")) return true;
-                if (ArgContains(argStrings, "KL30B_EIN")) return false;
-                if (ArgContains(argStrings, "KL30F_EIN")) return false;
-                if (ArgContains(argStrings, "KL30B_EIN_VERK")) return false;
-                if (ArgContains(argStrings, "KLR_EIN")) return false;
-                if (ArgContains(argStrings, "KL15_AUS")) return false;
+                resultName = "STAT_CAS_KLEMMEN_STATUS_TEXT";
             }
-            // Generic UDS RoutineControl used for the KL15 shutdown across BDC/FEM/ZGW/CAS4 variants.
-            // Identified either by routine name (STEUERN_KL15_ABSCHALTUNG, or the KLEMME15 fallback
-            // spelling) or by routine id 0xAC51 (CAS4_2 uses ID;0xAC51 with no name). The STR/value
-            // suffix varies (STR;3 / STR;30) and is irrelevant here.
-            if (string.Equals(jobName, "STEUERN_ROUTINE", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(jobName, "STATUS_LESEN", StringComparison.OrdinalIgnoreCase) && ArgContains(argStrings, "STATUS_KLEMMEN"))
             {
-                if (ArgContains(argStrings, "STEUERN_KL15_ABSCHALTUNG")) return false;
-                if (ArgContains(argStrings, "STEUERN_KLEMME15_ABSCHALTUNG")) return false;
-                if (ArgContains(argStrings, "0xAC51")) return false;
+                resultName = "STAT_KLEMMENSTATUS_TEXT";
             }
-            return null;
-        }
-
-        // Live clamp state from the targeted STATUS_LESEN / STATUS_KLEMMEN read (BDC/CAS). The result
-        // STAT_KLEMMENSTATUS_TEXT is the decoded table entry: "KL15" => clamp on, "KL30B" => off.
-        // We decode by text (a code, not a bit field: 0x0A=KL15, 0x06=KL30B, so a & 0x01 test is
-        // wrong). Strictly scoped to this job+arg so it never reads a fault freeze-frame's KLEMMEN
-        // field (which is historical, not the live state).
-        private static bool? InferClampFromStatus(string jobName, List<string> argStrings, List<Dictionary<string, EdiabasNet.ResultData>> resultSets)
-        {
-            if (!string.Equals(jobName, "STATUS_LESEN", StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-            if (!ArgContains(argStrings, "STATUS_KLEMMEN") || resultSets == null)
+            if (resultName == null || resultSets == null)
             {
                 return null;
             }
             for (int i = 1; i < resultSets.Count; i++)
             {
                 Dictionary<string, EdiabasNet.ResultData> set = resultSets[i];
-                if (set == null)
-                {
-                    continue;
-                }
-                if (set.TryGetValue("STAT_KLEMMENSTATUS_TEXT", out EdiabasNet.ResultData rd) && rd?.OpData is string text)
+                if (set != null && set.TryGetValue(resultName, out EdiabasNet.ResultData rd) && rd?.OpData is string text)
                 {
                     // Documented values: KL15 | KL30B[_EIN] | KL30F_EIN | KLR_EIN. Only KL15 = on.
                     if (text.StartsWith("KL15", StringComparison.OrdinalIgnoreCase)) return true;
                     if (text.StartsWith("KL30", StringComparison.OrdinalIgnoreCase)) return false;
                     if (text.StartsWith("KLR", StringComparison.OrdinalIgnoreCase)) return false;
                 }
+            }
+            return null;
+        }
+
+        // The KL15 shutdown routine carries no clamp-status result (only a positive UDS ACK), so it
+        // is recognized by intent. Identified by routine name (STEUERN_KL15_ABSCHALTUNG, or the
+        // KLEMME15 fallback spelling), by routine id 0xAC51 (CAS4_2 uses ID;0xAC51 with no name), or
+        // as a direct job (BN2000 / d_cas). Always means KL15 off.
+        private static bool? InferClampFromShutdownCommand(string jobName, List<string> argStrings)
+        {
+            if (string.Equals(jobName, "STEUERN_KL15_ABSCHALTUNG", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            if (string.Equals(jobName, "STEUERN_ROUTINE", StringComparison.OrdinalIgnoreCase))
+            {
+                if (ArgContains(argStrings, "STEUERN_KL15_ABSCHALTUNG")) return false;
+                if (ArgContains(argStrings, "STEUERN_KLEMME15_ABSCHALTUNG")) return false;
+                if (ArgContains(argStrings, "0xAC51")) return false;
             }
             return null;
         }

--- a/EdiabasLib/EdiabasLib/EdInterfaceEnet.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceEnet.cs
@@ -1560,10 +1560,9 @@ namespace EdiabasLib
             }
         }
 
-        // Serialized HSFZ control-channel ignition (clamp 15) read shared by the public
-        // IgnitionVoltage getter and the voltage sampler's ReadIgnitionForPublish. The whole
-        // connect/write/read transaction runs under TcpControlReadLock so a background sampler
-        // read on the timer thread cannot interleave with a foreground read on TcpControlStream.
+        // Serialized HSFZ control-channel ignition (clamp 15) read used by the public
+        // IgnitionVoltage getter. The whole connect/write/read transaction runs under
+        // TcpControlReadLock so concurrent reads cannot interleave on TcpControlStream.
         // Uses a local buffer (never the shared RecBuffer).
         //   return: true = ignition on, false = off, null = could not determine
         //   errorCode: EDIABAS_ERR_NONE on a clean read; EDIABAS_IFH_0003 on a transaction failure
@@ -1611,26 +1610,101 @@ namespace EdiabasLib
         }
 
 #if NETFRAMEWORK
-        // Side-effect-free ignition (clamp 15) read for the ENET voltage bridge: shares the
-        // serialized control-channel transaction with IgnitionVoltage, but never sets an error
-        // and returns null when the state cannot be determined.
-        private bool? ReadIgnitionForPublish()
+        // ENET clamp following is command-snoop based, NOT a live read: the vehicle exposes no KL15
+        // over the diagnostic bus (on a genuine setup it is an ICOM/SLP hardware signal, cf. ISTA
+        // VCIDevice.GetClamp15 <- SLP advertisement). So instead of polling the control channel
+        // (unreliable: it is never queried for ignition and the connection churns), we passively
+        // mirror ISTA's own explicit clamp-control commands as they cross the wire. Invoked by
+        // EdiabasNet at the end of each user ExecuteJob - no extra bus traffic, no thread, no I/O.
+        // Recognized commands (observed in live ISTA traces):
+        //   * STEUERN_KLEMMEN arg KL15_EIN                 -> KL15 on  (restore)
+        //   * STEUERN_KLEMMEN arg KL30B_EIN / KL15_AUS     -> KL15 off (service / KLwechsel)
+        //   * STEUERN_ROUTINE arg STEUERN_KL15_ABSCHALTUNG -> KL15 off (post-DTC-clear cycle)
+        // Every other job leaves the held state untouched. We deliberately do NOT infer "on" from
+        // arbitrary successful jobs (that masks a real off within milliseconds) and never read fault
+        // freeze-frames (their KLEMMEN fields are historical, not the live state). The consumer
+        // holds the last state and restores ON on KL15_EIN (or via its own safety timeout).
+        public override void OnJobCompleted(string jobName, List<string> argStrings, List<Dictionary<string, EdiabasNet.ResultData>> resultSets)
         {
-            if (SharedDataActive.DiagRplus)
+            if (!EnableVoltageSamplerProtected)
+            {   // EnetEnableVoltageSampler=0: do not feed the bridge at all
+                return;
+            }
+            if (!EdiabasVoltageBridge.HasSink || string.IsNullOrEmpty(jobName))
             {
-                // ICOM/RPLUS: ignition is read over the diagnostic (NMP) channel; do not
-                // poll it passively to avoid interfering with the diagnostic session.
+                return;
+            }
+            // An explicit command takes priority (immediate reaction); otherwise an authoritative
+            // STATUS_KLEMMEN read gives the live state, including the session-start baseline.
+            bool? clampOn = InferClampFromCommand(jobName, argStrings)
+                            ?? InferClampFromStatus(jobName, argStrings, resultSets);
+            if (!clampOn.HasValue)
+            {   // neither a clamp command nor a clamp status read: hold the last published state
+                return;
+            }
+            EdiabasVoltageBridge.Sample(true, clampOn, IgnitionVoltageValue, BatteryVoltageValue, RemoteHostProtected);
+        }
+
+        private static bool? InferClampFromCommand(string jobName, List<string> argStrings)
+        {
+            if (string.Equals(jobName, "STEUERN_KLEMMEN", StringComparison.OrdinalIgnoreCase))
+            {
+                if (ArgContains(argStrings, "KL15_EIN")) return true;
+                if (ArgContains(argStrings, "KL30B_EIN")) return false;
+                if (ArgContains(argStrings, "KL15_AUS")) return false;
+            }
+            if (string.Equals(jobName, "STEUERN_ROUTINE", StringComparison.OrdinalIgnoreCase))
+            {
+                if (ArgContains(argStrings, "STEUERN_KL15_ABSCHALTUNG")) return false;
+            }
+            return null;
+        }
+
+        // Live clamp state from the targeted STATUS_LESEN / STATUS_KLEMMEN read (BDC/CAS). The result
+        // STAT_KLEMMENSTATUS_TEXT is the decoded table entry: "KL15" => clamp on, "KL30B" => off.
+        // We decode by text (a code, not a bit field: 0x0A=KL15, 0x06=KL30B, so a & 0x01 test is
+        // wrong). Strictly scoped to this job+arg so it never reads a fault freeze-frame's KLEMMEN
+        // field (which is historical, not the live state).
+        private static bool? InferClampFromStatus(string jobName, List<string> argStrings, List<Dictionary<string, EdiabasNet.ResultData>> resultSets)
+        {
+            if (!string.Equals(jobName, "STATUS_LESEN", StringComparison.OrdinalIgnoreCase))
+            {
                 return null;
             }
-            if (IsSimulationMode())
+            if (!ArgContains(argStrings, "STATUS_KLEMMEN") || resultSets == null)
             {
                 return null;
             }
-            if (!Connected)
+            for (int i = 1; i < resultSets.Count; i++)
             {
-                return null;
+                Dictionary<string, EdiabasNet.ResultData> set = resultSets[i];
+                if (set == null)
+                {
+                    continue;
+                }
+                if (set.TryGetValue("STAT_KLEMMENSTATUS_TEXT", out EdiabasNet.ResultData rd) && rd?.OpData is string text)
+                {
+                    if (text.StartsWith("KL15", StringComparison.OrdinalIgnoreCase)) return true;
+                    if (text.StartsWith("KL30", StringComparison.OrdinalIgnoreCase)) return false;
+                }
             }
-            return ReadIgnitionControlState(out _);
+            return null;
+        }
+
+        private static bool ArgContains(List<string> argStrings, string needle)
+        {
+            if (argStrings == null)
+            {
+                return false;
+            }
+            for (int i = 0; i < argStrings.Count; i++)
+            {
+                if (string.Equals(argStrings[i], needle, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 #endif
 
@@ -1808,7 +1882,10 @@ namespace EdiabasLib
 #if NETFRAMEWORK
             if (EnableVoltageSampler)
             {
-                EdiabasVoltageSampler.Start(RemoteHostProtected, () => Connected, ReadIgnitionForPublish, () => IgnitionVoltageValue, () => BatteryVoltageValue);
+                // No timer/control-channel poll for ENET (no reliable live KL15 - see OnJobCompleted).
+                // Publish a default ON snapshot so the consumer shows the nominal immediately;
+                // OnJobCompleted then mirrors ISTA's explicit KLwechsel commands.
+                EdiabasVoltageBridge.Sample(true, true, IgnitionVoltageValue, BatteryVoltageValue, RemoteHostProtected);
             }
 #endif
             return InterfaceConnect(false);
@@ -2355,7 +2432,7 @@ namespace EdiabasLib
 #if NETFRAMEWORK
             if (EnableVoltageSampler)
             {
-                EdiabasVoltageSampler.Stop(RemoteHostProtected);
+                EdiabasVoltageBridge.Detached(RemoteHostProtected);
             }
 #endif
             if (!base.InterfaceDisconnect())

--- a/EdiabasLib/EdiabasLib/EdInterfaceEnet.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceEnet.cs
@@ -1616,10 +1616,13 @@ namespace EdiabasLib
         // (unreliable: it is never queried for ignition and the connection churns), we passively
         // mirror ISTA's own explicit clamp-control commands as they cross the wire. Invoked by
         // EdiabasNet at the end of each user ExecuteJob - no extra bus traffic, no thread, no I/O.
-        // Recognized commands (observed in live ISTA traces):
-        //   * STEUERN_KLEMMEN arg KL15_EIN                 -> KL15 on  (restore)
-        //   * STEUERN_KLEMMEN arg KL30B_EIN / KL15_AUS     -> KL15 off (service / KLwechsel)
-        //   * STEUERN_ROUTINE arg STEUERN_KL15_ABSCHALTUNG -> KL15 off (post-DTC-clear cycle)
+        // Recognized signals (per ISTA 4.59.20 variant analysis + live traces):
+        //   * STEUERN_KLEMMEN arg KL15_EIN                       -> KL15 on  (restore)
+        //   * STEUERN_KLEMMEN arg KL30B/KL30F/..._VERK/KLR/AUS   -> KL15 off (non-ignition clamp)
+        //   * STEUERN_ROUTINE arg STEUERN_KL15_ABSCHALTUNG /     -> KL15 off (shutdown; also the
+        //       KLEMME15 fallback spelling, or routine id 0xAC51 used by CAS4_2)
+        //   * STEUERN_KL15_ABSCHALTUNG as a direct job (BN2000)  -> KL15 off
+        //   * STATUS_LESEN/STATUS_KLEMMEN STAT_KLEMMENSTATUS_TEXT -> live state + session baseline
         // Every other job leaves the held state untouched. We deliberately do NOT infer "on" from
         // arbitrary successful jobs (that masks a real off within milliseconds) and never read fault
         // freeze-frames (their KLEMMEN fields are historical, not the live state). The consumer
@@ -1647,15 +1650,31 @@ namespace EdiabasLib
 
         private static bool? InferClampFromCommand(string jobName, List<string> argStrings)
         {
+            // Direct shutdown job (BN2000 / d_cas): the routine is the job itself, not a ROUTINE arg.
+            if (string.Equals(jobName, "STEUERN_KL15_ABSCHALTUNG", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            // Direct clamp switch. KL15_EIN = ignition on; every other target clamp (KL30B/KL30F/
+            // shortened-nachlauf VERK / KLR / explicit AUS) means KL15 off.
             if (string.Equals(jobName, "STEUERN_KLEMMEN", StringComparison.OrdinalIgnoreCase))
             {
                 if (ArgContains(argStrings, "KL15_EIN")) return true;
                 if (ArgContains(argStrings, "KL30B_EIN")) return false;
+                if (ArgContains(argStrings, "KL30F_EIN")) return false;
+                if (ArgContains(argStrings, "KL30B_EIN_VERK")) return false;
+                if (ArgContains(argStrings, "KLR_EIN")) return false;
                 if (ArgContains(argStrings, "KL15_AUS")) return false;
             }
+            // Generic UDS RoutineControl used for the KL15 shutdown across BDC/FEM/ZGW/CAS4 variants.
+            // Identified either by routine name (STEUERN_KL15_ABSCHALTUNG, or the KLEMME15 fallback
+            // spelling) or by routine id 0xAC51 (CAS4_2 uses ID;0xAC51 with no name). The STR/value
+            // suffix varies (STR;3 / STR;30) and is irrelevant here.
             if (string.Equals(jobName, "STEUERN_ROUTINE", StringComparison.OrdinalIgnoreCase))
             {
                 if (ArgContains(argStrings, "STEUERN_KL15_ABSCHALTUNG")) return false;
+                if (ArgContains(argStrings, "STEUERN_KLEMME15_ABSCHALTUNG")) return false;
+                if (ArgContains(argStrings, "0xAC51")) return false;
             }
             return null;
         }
@@ -1684,8 +1703,10 @@ namespace EdiabasLib
                 }
                 if (set.TryGetValue("STAT_KLEMMENSTATUS_TEXT", out EdiabasNet.ResultData rd) && rd?.OpData is string text)
                 {
+                    // Documented values: KL15 | KL30B[_EIN] | KL30F_EIN | KLR_EIN. Only KL15 = on.
                     if (text.StartsWith("KL15", StringComparison.OrdinalIgnoreCase)) return true;
                     if (text.StartsWith("KL30", StringComparison.OrdinalIgnoreCase)) return false;
+                    if (text.StartsWith("KLR", StringComparison.OrdinalIgnoreCase)) return false;
                 }
             }
             return null;

--- a/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
@@ -62,7 +62,6 @@ namespace EdiabasLib
             SingleTransmit,     // single data transmission
             FrequentMode,       // frequent mode setting
             IdleTransmit,       // idle data transmission
-            SampleClamp,        // out-of-band passive DSR read for the voltage bridge
             Exit,               // exit thread
         }
 
@@ -132,6 +131,11 @@ namespace EdiabasLib
         // on the timer-thread read path. Static so the last known value survives the per-
         // reconnect EdInterfaceObd instance churn driven by ISTA (ECUKom.End/InitVCI).
         protected static int SampledDsrState;
+        // Set by the voltage sampler timer thread to request a clamp read; serviced by the
+        // CommThread on its next Idle/IdleTransmit iteration, so the read is never concurrent
+        // with TX/RX yet still fires during an active session (where the thread sits in
+        // IdleTransmit running the keep-alive) — unlike an Idle-only trigger.
+        protected volatile bool SampleClampPending;
         protected List<int> DisabledConceptsListProtected = null;
         protected double DtrTimeCorrCom = 0.3;
         protected double DtrTimeCorrFtdi = 0.3;
@@ -1375,7 +1379,7 @@ namespace EdiabasLib
 
 #if NETFRAMEWORK
             // OBD voltage bridge: passive sampling of the clamp state (ignition via DSR).
-            // The actual DSR read is performed on the CommThread (case SampleClamp) so it never
+            // The actual DSR read is performed on the CommThread (see SampleClampPending) so it never
             // races with normal communication, even on extension interfaces (BT/USB/ELM) whose
             // InterfaceGetDsr delegate may share state with the TX/RX delegates. The sampler's
             // timer thread only posts a request and reads the latest snapshot (1 s of latency
@@ -1384,7 +1388,7 @@ namespace EdiabasLib
             {
                 // Do NOT reset SampledDsrState here: ISTA often re-connects every few seconds,
                 // and the clamp physically doesn't change across a reconnect. Keeping the last
-                // known value avoids a "null" burst until the first SampleClamp completes in
+                // known value avoids a "null" burst until the first clamp sample completes in
                 // the new connection window (which may not happen at all on very short windows).
                 EdiabasVoltageSampler.Start(ComPortProtected, () => Connected, ReadSampledDsr, () => IgnitionVoltageValue, () => BatteryVoltageValue, RequestDsrSample);
             }
@@ -2898,23 +2902,18 @@ namespace EdiabasLib
 #endif
 
 #if NETFRAMEWORK
-        // Posts an out-of-band SampleClamp request onto the CommThread queue. The actual
-        // ReadDsrRaw() then runs in the CommThread context, never racing with TX/RX.
-        // Idle-only: if the CommThread is busy with a user transmission, the sample is
-        // simply skipped this tick and re-posted on the next sampler timer tick.
+        // Requests a clamp (DSR) read from the voltage sampler's timer thread. Only sets a flag;
+        // the CommThread performs the actual ReadDsrRaw() on its next Idle/IdleTransmit iteration,
+        // so the InterfaceGetDsr delegate is never touched concurrently with TX/RX. The flag
+        // persists until serviced, so it also fires during an active session (where the thread
+        // sits in IdleTransmit running the keep-alive), not only when fully idle.
         private void RequestDsrSample()
         {
             if (IsSimulationMode())
             {
                 return;
             }
-            lock (CommThreadLock)
-            {
-                if (CommThreadCommand == CommThreadCommands.Idle)
-                {
-                    CommThreadCommand = CommThreadCommands.SampleClamp;
-                }
-            }
+            SampleClampPending = true;
             CommThreadReqEvent.Set();
         }
 
@@ -3042,24 +3041,21 @@ namespace EdiabasLib
                             break;
                         }
 
-                    case CommThreadCommands.SampleClamp:
-                        {
-                            // Out-of-band passive read posted by EdiabasVoltageSampler.
-                            // Runs on the CommThread so the InterfaceGetDsr delegate is never
-                            // touched concurrently with TX/RX. No SetError, no bus traffic.
-                            bool? dsr = ReadDsrRaw();
-                            int newState = dsr.HasValue ? (dsr.Value ? 1 : 2) : 0;
-                            Interlocked.Exchange(ref SampledDsrState, newState);
-                            lock (CommThreadLock)
-                            {
-                                if (CommThreadCommand == CommThreadCommands.SampleClamp)
-                                {
-                                    CommThreadCommand = CommThreadCommands.Idle;
-                                }
-                            }
-                            break;
-                        }
                 }
+
+#if NETFRAMEWORK
+                // Voltage bridge: service a pending passive clamp (DSR) read on the CommThread,
+                // but only while idle or running the keep-alive (never mid user transmission), and
+                // after the keep-alive cycle so it isn't delayed. ReadDsrRaw() touches the
+                // InterfaceGetDsr delegate on this thread only, so it never races with TX/RX.
+                if (SampleClampPending &&
+                    (command == CommThreadCommands.Idle || command == CommThreadCommands.IdleTransmit))
+                {
+                    SampleClampPending = false;
+                    bool? dsr = ReadDsrRaw();
+                    Interlocked.Exchange(ref SampledDsrState, dsr.HasValue ? (dsr.Value ? 1 : 2) : 0);
+                }
+#endif
 
                 if (!newRequest)
                 {

--- a/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
@@ -129,8 +129,9 @@ namespace EdiabasLib
         protected bool EnableVoltageSamplerProtected = false;
         // Snapshot of the last DSR read performed on the CommThread for the voltage bridge.
         // 0 = unknown, 1 = asserted (true), 2 = deasserted (false). Interlocked to avoid a lock
-        // on the timer-thread read path.
-        protected int SampledDsrState;
+        // on the timer-thread read path. Static so the last known value survives the per-
+        // reconnect EdInterfaceObd instance churn driven by ISTA (ECUKom.End/InitVCI).
+        protected static int SampledDsrState;
         protected List<int> DisabledConceptsListProtected = null;
         protected double DtrTimeCorrCom = 0.3;
         protected double DtrTimeCorrFtdi = 0.3;

--- a/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
@@ -1369,9 +1369,18 @@ namespace EdiabasLib
 
 #if NETFRAMEWORK
             // OBD voltage bridge: passive sampling of the clamp state (ignition via DSR).
-            if (EnableVoltageSampler)
+            // Gated to raw COM only: on extension interfaces (BT/USB/ELM) the InterfaceGetDsr
+            // delegate may share state with the data TX/RX delegates that the CommThread uses,
+            // and the sampler runs on its own Timer thread -> race with normal communication.
+            // A future change can move the sampler read into the CommThread context (see
+            // case SampleClamp in CommThreadFunc) and lift this restriction.
+            if (EnableVoltageSampler && !UseExtInterfaceFunc)
             {
                 EdiabasVoltageSampler.Start(ComPortProtected, () => Connected, ReadDsrForPublish, () => IgnitionVoltageValue, () => BatteryVoltageValue);
+            }
+            else if (EnableVoltageSampler)
+            {
+                EdiabasProtected.LogString(EdiabasNet.EdLogLevel.Ifh, "Voltage sampler disabled on extended interface (unsafe with foreign comm thread)");
             }
 #endif
 
@@ -1564,7 +1573,7 @@ namespace EdiabasLib
             StopCommThread();
 
 #if NETFRAMEWORK
-            if (EnableVoltageSampler)
+            if (EnableVoltageSampler && !UseExtInterfaceFunc)
             {
                 EdiabasVoltageSampler.Stop(ComPortProtected);
             }

--- a/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
@@ -1381,7 +1381,10 @@ namespace EdiabasLib
             // is acceptable for a slow-changing clamp signal).
             if (EnableVoltageSampler)
             {
-                SampledDsrState = 0;
+                // Do NOT reset SampledDsrState here: ISTA often re-connects every few seconds,
+                // and the clamp physically doesn't change across a reconnect. Keeping the last
+                // known value avoids a "null" burst until the first SampleClamp completes in
+                // the new connection window (which may not happen at all on very short windows).
                 EdiabasVoltageSampler.Start(ComPortProtected, () => Connected, ReadSampledDsr, () => IgnitionVoltageValue, () => BatteryVoltageValue, RequestDsrSample);
             }
 #endif

--- a/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
@@ -2824,49 +2824,13 @@ namespace EdiabasLib
                 InterfaceReceiveDataFuncUse != null;
         }
 
-        protected bool GetDsrState()
-        {
-            if (!UseExtInterfaceFunc)
-            {
-#if USE_SERIAL_PORT
-                try
-                {
-                    if (!SerialPort.IsOpen)
-                    {
-                        EdiabasProtected.SetError(EdiabasNet.ErrorCodes.EDIABAS_IFH_0019);
-                        return false;
-                    }
-                    return SerialPort.DsrHolding;
-                }
-                catch (Exception)
-                {
-                    return false;
-                }
-#else
-                return false;
-#endif
-            }
-
-            bool dsrState;
-            if (!InterfaceGetDsrFuncUse(out dsrState))
-            {
-                EdiabasProtected.SetError(EdiabasNet.ErrorCodes.EDIABAS_IFH_0019);
-                return false;
-            }
-            return dsrState;
-        }
-
-#if NETFRAMEWORK || WINDOWS
-        // Side-effect-free DSR read (no SetError) for the OBD voltage bridge.
-        // Returns null if the state cannot be read. No traffic on the bus.
-        private bool? ReadDsrForPublish()
+        // Raw DSR line read with no side effects (no SetError, no bus traffic): true/false = line
+        // state, null = cannot read. Shared by GetDsrState (public, maps null -> IFH_0019) and
+        // ReadDsrForPublish (voltage bridge, maps null -> unknown).
+        private bool? ReadDsrRaw()
         {
             try
             {
-                if (IsSimulationMode())
-                {
-                    return null;
-                }
                 if (!UseExtInterfaceFunc)
                 {
 #if USE_SERIAL_PORT
@@ -2880,17 +2844,40 @@ namespace EdiabasLib
 #endif
                 }
                 InterfaceGetDsrDelegate f = InterfaceGetDsrFuncUse;
-                bool dsrStatePub;
-                if (f != null && f(out dsrStatePub))
+                bool dsrState;
+                if (f != null && f(out dsrState))
                 {
-                    return dsrStatePub;
+                    return dsrState;
                 }
                 return null;
             }
-            catch
+            catch (Exception)
             {
                 return null;
             }
+        }
+
+        protected bool GetDsrState()
+        {
+            bool? dsrState = ReadDsrRaw();
+            if (dsrState.HasValue)
+            {
+                return dsrState.Value;
+            }
+            EdiabasProtected.SetError(EdiabasNet.ErrorCodes.EDIABAS_IFH_0019);
+            return false;
+        }
+
+#if NETFRAMEWORK || WINDOWS
+        // Side-effect-free DSR read (no SetError) for the OBD voltage bridge.
+        // Returns null if the state cannot be read. No traffic on the bus.
+        private bool? ReadDsrForPublish()
+        {
+            if (IsSimulationMode())
+            {
+                return null;
+            }
+            return ReadDsrRaw();
         }
 #endif
 

--- a/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
+++ b/EdiabasLib/EdiabasLib/EdInterfaceObd.cs
@@ -62,6 +62,7 @@ namespace EdiabasLib
             SingleTransmit,     // single data transmission
             FrequentMode,       // frequent mode setting
             IdleTransmit,       // idle data transmission
+            SampleClamp,        // out-of-band passive DSR read for the voltage bridge
             Exit,               // exit thread
         }
 
@@ -126,6 +127,10 @@ namespace EdiabasLib
         protected int UdsEcuCanIdOverrideProtected = -1;
         protected int UdsTesterCanIdOverrideProtected = -1;
         protected bool EnableVoltageSamplerProtected = false;
+        // Snapshot of the last DSR read performed on the CommThread for the voltage bridge.
+        // 0 = unknown, 1 = asserted (true), 2 = deasserted (false). Interlocked to avoid a lock
+        // on the timer-thread read path.
+        protected int SampledDsrState;
         protected List<int> DisabledConceptsListProtected = null;
         protected double DtrTimeCorrCom = 0.3;
         protected double DtrTimeCorrFtdi = 0.3;
@@ -1369,18 +1374,15 @@ namespace EdiabasLib
 
 #if NETFRAMEWORK
             // OBD voltage bridge: passive sampling of the clamp state (ignition via DSR).
-            // Gated to raw COM only: on extension interfaces (BT/USB/ELM) the InterfaceGetDsr
-            // delegate may share state with the data TX/RX delegates that the CommThread uses,
-            // and the sampler runs on its own Timer thread -> race with normal communication.
-            // A future change can move the sampler read into the CommThread context (see
-            // case SampleClamp in CommThreadFunc) and lift this restriction.
-            if (EnableVoltageSampler && !UseExtInterfaceFunc)
+            // The actual DSR read is performed on the CommThread (case SampleClamp) so it never
+            // races with normal communication, even on extension interfaces (BT/USB/ELM) whose
+            // InterfaceGetDsr delegate may share state with the TX/RX delegates. The sampler's
+            // timer thread only posts a request and reads the latest snapshot (1 s of latency
+            // is acceptable for a slow-changing clamp signal).
+            if (EnableVoltageSampler)
             {
-                EdiabasVoltageSampler.Start(ComPortProtected, () => Connected, ReadDsrForPublish, () => IgnitionVoltageValue, () => BatteryVoltageValue);
-            }
-            else if (EnableVoltageSampler)
-            {
-                EdiabasProtected.LogString(EdiabasNet.EdLogLevel.Ifh, "Voltage sampler disabled on extended interface (unsafe with foreign comm thread)");
+                SampledDsrState = 0;
+                EdiabasVoltageSampler.Start(ComPortProtected, () => Connected, ReadSampledDsr, () => IgnitionVoltageValue, () => BatteryVoltageValue, RequestDsrSample);
             }
 #endif
 
@@ -1573,7 +1575,7 @@ namespace EdiabasLib
             StopCommThread();
 
 #if NETFRAMEWORK
-            if (EnableVoltageSampler && !UseExtInterfaceFunc)
+            if (EnableVoltageSampler)
             {
                 EdiabasVoltageSampler.Stop(ComPortProtected);
             }
@@ -2880,6 +2882,7 @@ namespace EdiabasLib
 #if NETFRAMEWORK || WINDOWS
         // Side-effect-free DSR read (no SetError) for the OBD voltage bridge.
         // Returns null if the state cannot be read. No traffic on the bus.
+        // Kept for callers that don't go through the CommThread (e.g. raw probes).
         private bool? ReadDsrForPublish()
         {
             if (IsSimulationMode())
@@ -2887,6 +2890,38 @@ namespace EdiabasLib
                 return null;
             }
             return ReadDsrRaw();
+        }
+#endif
+
+#if NETFRAMEWORK
+        // Posts an out-of-band SampleClamp request onto the CommThread queue. The actual
+        // ReadDsrRaw() then runs in the CommThread context, never racing with TX/RX.
+        // Idle-only: if the CommThread is busy with a user transmission, the sample is
+        // simply skipped this tick and re-posted on the next sampler timer tick.
+        private void RequestDsrSample()
+        {
+            if (IsSimulationMode())
+            {
+                return;
+            }
+            lock (CommThreadLock)
+            {
+                if (CommThreadCommand == CommThreadCommands.Idle)
+                {
+                    CommThreadCommand = CommThreadCommands.SampleClamp;
+                }
+            }
+            CommThreadReqEvent.Set();
+        }
+
+        // Snapshot read of the latest DSR value sampled by the CommThread. Safe to call from
+        // any thread (Interlocked-published int). Returns null if no sample is available yet.
+        private bool? ReadSampledDsr()
+        {
+            int v = Interlocked.CompareExchange(ref SampledDsrState, 0, 0);
+            if (v == 1) return true;
+            if (v == 2) return false;
+            return null;
         }
 #endif
 
@@ -2998,6 +3033,24 @@ namespace EdiabasLib
                                     {
                                         CommThreadCommand = CommThreadCommands.Idle;
                                     }
+                                }
+                            }
+                            break;
+                        }
+
+                    case CommThreadCommands.SampleClamp:
+                        {
+                            // Out-of-band passive read posted by EdiabasVoltageSampler.
+                            // Runs on the CommThread so the InterfaceGetDsr delegate is never
+                            // touched concurrently with TX/RX. No SetError, no bus traffic.
+                            bool? dsr = ReadDsrRaw();
+                            int newState = dsr.HasValue ? (dsr.Value ? 1 : 2) : 0;
+                            Interlocked.Exchange(ref SampledDsrState, newState);
+                            lock (CommThreadLock)
+                            {
+                                if (CommThreadCommand == CommThreadCommands.SampleClamp)
+                                {
+                                    CommThreadCommand = CommThreadCommands.Idle;
                                 }
                             }
                             break;

--- a/EdiabasLib/EdiabasLib/EdiabasNet.cs
+++ b/EdiabasLib/EdiabasLib/EdiabasNet.cs
@@ -5728,6 +5728,15 @@ namespace EdiabasLib
             }
             finally
             {
+#if NETFRAMEWORK
+                // Passive, never-throwing post-job hook (ENET snoops STEUERN_KLEMMEN / STEUERN_ROUTINE
+                // to mirror ISTA's KLwechsel commands to the voltage bridge - no extra bus traffic).
+                // Capture args BEFORE the BinData reset below so the hook still sees them.
+                List<string> capturedArgStrings = null;
+                try { capturedArgStrings = GetActiveArgStrings(); } catch { }
+                try { EdInterfaceClass?.OnJobCompleted(jobName, capturedArgStrings, ResultSets); }
+                catch { }
+#endif
                 _argInfo.BinData = null;
                 _argInfoStd.BinData = null;
                 _jobStd = false;

--- a/EdiabasLib/EdiabasLib/EdiabasVoltageBridge.cs
+++ b/EdiabasLib/EdiabasLib/EdiabasVoltageBridge.cs
@@ -21,6 +21,13 @@ namespace EdiabasLib
     {
         public const int Version = 1;
 
+        // EdiabasLib's nominal voltages when no measurement / per-interface config override exists.
+        // Exposed so the in-process consumer can seed a sensible "auto" display value BEFORE the
+        // first sample, without hardcoding the same number on its side. Matches EdInterfaceEnet's
+        // protected defaults (12000 mV).
+        public static int NominalIgnitionMv = 12000;
+        public static int NominalBatteryMv = 12000;
+
         // onSample(connected, clampOn, ignitionNominalMv, batteryNominalMv, connectionId)
         //   clampOn: true = KL15 on, false = off, null = unknown (consumer decides hold-last)
         //   *NominalMv: configured nominal (EnetIgnitionVoltage / OBD equivalent), not a measurement

--- a/EdiabasLib/EdiabasLib/EdiabasVoltageSampler.cs
+++ b/EdiabasLib/EdiabasLib/EdiabasVoltageSampler.cs
@@ -13,6 +13,13 @@ namespace EdiabasLib
     /// plain EdiabasLib instance with no consumer does nothing (no timer, no allocations, no IPC).
     /// Only the raw state is reported; presentation policy (e.g. holding the last value on an
     /// unknown read) lives in the consumer.
+    ///
+    /// Thread-safety: the timer thread MUST NOT touch the transport directly when the transport
+    /// has a dedicated owner thread (OBD CommThread, future ENET equivalent). In that case the
+    /// interface passes a non-null <c>requestSample</c> action that enqueues a fresh read on the
+    /// owner thread; the <c>clamp</c> delegate then just returns the latest published snapshot.
+    /// For interfaces without an owner thread (raw COM DSR is a hardware line, immune to
+    /// concurrency), <c>requestSample</c> may be null and <c>clamp</c> reads directly.
     /// </summary>
     internal static class EdiabasVoltageSampler
     {
@@ -21,12 +28,13 @@ namespace EdiabasLib
         private static bool _armed;                 // interface connected
         private static string _connectionId;
         private static Func<bool> _connected;
+        private static Action _requestSample;
         private static Func<bool?> _clamp;
         private static Func<int> _ignNom;
         private static Func<int> _battNom;
 
         /// <summary>Arms sampling for a connected interface; the timer starts only if a consumer is present.</summary>
-        public static void Start(string connectionId, Func<bool> connected, Func<bool?> clamp, Func<int> ignNomMv, Func<int> battNomMv)
+        public static void Start(string connectionId, Func<bool> connected, Func<bool?> clamp, Func<int> ignNomMv, Func<int> battNomMv, Action requestSample = null)
         {
             lock (Lock)
             {
@@ -34,6 +42,7 @@ namespace EdiabasLib
                 _armed = true;
                 _connectionId = connectionId;
                 _connected = connected;
+                _requestSample = requestSample;
                 _clamp = clamp;
                 _ignNom = ignNomMv;
                 _battNom = battNomMv;
@@ -52,6 +61,7 @@ namespace EdiabasLib
                 _armed = false;
                 StopTimer();
                 _connected = null;
+                _requestSample = null;
                 _clamp = null;
                 _ignNom = null;
                 _battNom = null;
@@ -81,6 +91,7 @@ namespace EdiabasLib
         {
             string connectionId;
             Func<bool> connected;
+            Action requestSample;
             Func<bool?> clamp;
             Func<int> ignNom;
             Func<int> battNom;
@@ -92,6 +103,7 @@ namespace EdiabasLib
                 }
                 connectionId = _connectionId;
                 connected = _connected;
+                requestSample = _requestSample;
                 clamp = _clamp;
                 ignNom = _ignNom;
                 battNom = _battNom;
@@ -103,6 +115,12 @@ namespace EdiabasLib
                 {
                     EdiabasVoltageBridge.Sample(false, null, 0, 0, connectionId);
                     return;
+                }
+                // Owner-thread model: enqueue a fresh read; clamp() returns the previous snapshot.
+                // The 1 s latency is acceptable for a slow-changing clamp signal.
+                if (requestSample != null)
+                {
+                    try { requestSample(); } catch { }
                 }
                 bool? clampOn = clamp != null ? clamp() : (bool?)null;
                 EdiabasVoltageBridge.Sample(true, clampOn, Safe(ignNom), Safe(battNom), connectionId);


### PR DESCRIPTION
## Voltage bridge: OBD thread-safety redesign (CommThread) + ENET passive clamp readout

### Background

This addresses your review of the opt-in voltage bridge. You correctly identified the core design
flaw: the sampler ran on its own `System.Threading.Timer` thread and read the interface
(`InterfaceGetDsr` on OBD, the HSFZ control channel on ENET) **concurrently with normal
communication**, instead of using the owner thread. On a raw COM port that's harmless (DSR is an
independent modem-status line), but on extension interfaces (FTDI/BT/ELM) and ENET it shares state
with TX/RX → sporadic corruption / `IFH_0003`. This redesign removes the concurrent reads on both
transports.

### Changes

Files: `EdInterfaceObd.cs`, `EdInterfaceEnet.cs`, `EdiabasVoltageSampler.cs`, `EdInterfaceBase.cs`,
`EdiabasNet.cs`, `EdiabasVoltageBridge.cs`.

**1. OBD — move the sampler read onto the CommThread** — *the heart of your feedback*
- The raw DSR read is extracted into a side-effect-free `ReadDsrRaw()` (shared by `GetDsrState` and
  the bridge path).
- It is no longer done on the timer thread. The sampler timer only flags a request; the
  **`CommThread` performs `ReadDsrRaw()` itself**, so `InterfaceGetDsr` is never touched
  concurrently with TX/RX — safe on extension interfaces too.
- The result is published via an `Interlocked` `SampledDsrState`; `ReadSampledDsr()` returns the
  latest snapshot (≤1 s latency, fine for a slow clamp signal). It is `static` so the last value
  survives the per-reconnect `EdInterfaceObd` instance churn ISTA causes (`ECUKom.End`/`InitVCI`).

**2. OBD — sample during `IdleTransmit`, not only `Idle`**
- With an active protocol `ParIdleFunc` is set (`IdleIsoTp`, `IdleKwp2000Bmw`, …), so the CommThread
  sits in `IdleTransmit` running the keep-alive and never returns to `Idle`. An `Idle`-only trigger
  therefore almost never sampled *during* a session (exactly when `ClampSwitch`/KLwechsel happens).
  Replaced it with a `SampleClampPending` flag serviced in **both `Idle` and `IdleTransmit`** (after
  the keep-alive cycle, still on the CommThread).

**3. ENET — drop the control-channel sampler, read the vehicle-confirmed clamp state passively**
- The vehicle does not expose a live KL15 over the diagnostic bus on its own — on a genuine setup it
  is an ICOM hardware signal advertised out-of-band via SLP (cf. ISTA `VCIDevice.GetClamp15` ← SLP),
  and the HSFZ control channel is never reliably queried for ignition (it also churns:
  connect/disconnect per job via `ECUKomBase.ExecuteJobOverEnet`). So the timer-thread
  control-channel read is **removed** for ENET. `ReadIgnitionControlState` (serialized under a new
  per-`SharedData` `TcpControlReadLock`, local RX buffer) is kept only for the on-demand
  `IgnitionVoltage` getter.
- Instead, ENET surfaces the clamp by **reading the state the ECU itself reports**, through a new
  strictly-passive post-job hook: `EdInterfaceBase.OnJobCompleted` (default no-op), invoked by
  `EdiabasNet` at the end of each user `ExecuteJob` — never throws, no I/O, no extra bus traffic.
  `EdInterfaceEnet` decodes:
  - **the ECU-confirmed clamp-status text** (authoritative — the byte the gateway returns,
    `0x0A`=KL15 / `0x06`=KL30B, decoded by text not a bit test):
    - `STEUERN_KLEMMEN` → result `STAT_CAS_KLEMMEN_STATUS_TEXT` (state confirmed *after* the switch);
    - `STATUS_LESEN`/`STATUS_KLEMMEN` → result `STAT_KLEMMENSTATUS_TEXT` (live read; also the
      session-start baseline);
    - `"KL15"` → on, `"KL30…"`/`"KLR…"` → off;
  - **intent, only for the KL15 shutdown routine** (which carries no status text, just a UDS ACK):
    `STEUERN_ROUTINE STEUERN_KL15_ABSCHALTUNG` (or the `KLEMME15` fallback spelling, or routine id
    `0xAC51` used by CAS4_2), and `STEUERN_KL15_ABSCHALTUNG` as a direct job (BN2000 / `d_cas`) → off.
- Every other job leaves the held state untouched. It never infers "on" from arbitrary successful
  jobs, never reads fault freeze-frames (their KLEMMEN fields are historical, not live), and **holds
  rather than trusting a requested arg** when a `STEUERN_KLEMMEN` produced no confirmation. The
  job/result set was cross-checked against the per-gateway-variant dispatch in ISTA 4.59.20
  (`DiagnosticsBusinessData.ClampShutdownManagement` / `VehicleIdent.SwitchClamp15`) and the BDC,
  CAS4_2, FEM_20, ZGW and BN2000 ECU `.prg` definitions.

### Thread-safety rationale

All OBD sampler interface I/O now happens on the CommThread. The trigger is a single `volatile bool`
+ `Interlocked` snapshot — no lock on the timer-thread read path, and no second producer on the
single-producer CommThread request protocol (`SendBuffer`/`CommThreadReqCount` are untouched by the
sample path). The ENET hook is passive (no thread, no I/O), so it cannot race the transport.

### Scope / limitations (honest)

- **ENET clamp following is event-driven.** It updates when ISTA runs a `STEUERN_KLEMMEN` /
  `STATUS_KLEMMEN` / shutdown job (e.g. a clear-error-memory KLwechsel) — values are the
  ECU-confirmed state, not guesses, but there is no continuous polling between such events. The
  baseline before the first one is the configured nominal, published on connect.
- The `OnJobCompleted` hook touches core (`EdInterfaceBase` + `EdiabasNet`), but is a default-no-op
  virtual called once per `ExecuteJob`, guarded `#if NETFRAMEWORK`, and never throws.
- Both samplers remain **opt-in, default off** (`ObdEnableVoltageSampler` /
  `EnetEnableVoltageSampler`).

### Build / test

- `EdiabasLib.csproj -f net481`: 0 warnings, 0 errors.
- **OBD** (K+DCAN with EdiabasLib firmware): during an active session, `clampOn` updates ~1 Hz with
  no `IFH_0003`; KL15 voltage tracks ignition cut/restore.
- **ENET** (real vehicle, BDC gateway, clear-error-memory): each KLwechsel is detected from the
  ECU-confirmed `STAT_CAS_KLEMMEN_STATUS_TEXT` / `STAT_KLEMMENSTATUS_TEXT` — `clampOn` goes `False`
  and is held through the cut (KL15 → 0 mV, KL30 stays nominal), then back to `True` on restore,
  across multiple cycles, with no spurious flip-back. Other gateway variants (CAS4_2 / FEM / ZGW /
  BN2000) are covered from the source/`.prg` analysis but not yet hardware-tested.
